### PR TITLE
Updated README.md with missing devDependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ which points to
 
 ## Run it locally
 
-Make sure you have `ruby` and `jekyll` installed:
+Make sure you have `ruby`, `jekyll` and `jekyll-assets` installed:
 [jekyllrb.com](http://jekyllrb.com/). Then run:
 
     jekyll serve --watch


### PR DESCRIPTION
README was missing instructions to also install `jekyll-assets` gem which caused Jekyll to crash.