### PR TITLE
Removed type and density members from example

### DIFF
--- a/_posts/2014-11-10-Support-for-installable-web-apps-with-webapp-manifest-in-chrome-38-for-Android.md
+++ b/_posts/2014-11-10-Support-for-installable-web-apps-with-webapp-manifest-in-chrome-38-for-Android.md
@@ -38,39 +38,27 @@ You can call the manifest whatever you want.  Most people will probably just use
   "icons": [
     {
       "src": "launcher-icon-0-75x.png",
-      "sizes": "36x36",
-      "type": "image/png",
-      "density": "0.75"
+      "sizes": "36x36"
     },
     {
       "src": "launcher-icon-1x.png",
-      "sizes": "48x48",
-      "type": "image/png",
-      "density": "1.0"
+      "sizes": "48x48"
     },
     {
       "src": "launcher-icon-1-5x.png",
-      "sizes": "72x72",
-      "type": "image/png",
-      "density": "1.5"
+      "sizes": "72x72"
     },
     {
       "src": "launcher-icon-2x.png",
-      "sizes": "96x96",
-      "type": "image/png",
-      "density": "2.0"
+      "sizes": "96x96"
     },
     {
       "src": "launcher-icon-3x.png",
-      "sizes": "144x144",
-      "type": "image/png",
-      "density": "3.0"
+      "sizes": "144x144"
     },
     {
       "src": "launcher-icon-4x.png",
-      "sizes": "192x192",
-      "type": "image/png",
-      "density": "4.0"
+      "sizes": "192x192"
     }
   ],
   "start_url": "index.html",
@@ -83,7 +71,7 @@ Some interesting points in Chrome's implementation:
 
 *  The `short_name` is preferred over `name` and if provided will be used.
 *  If you don't supply a `start_url` it will use the current page's url.
-*  Chrome will [first look for icons](https://code.google.com/p/chromium/codesearch#chromium/src/chrome/browser/android/shortcut_helper.cc&l=182) that match the density of the display and are sized to [48dp * screen density](https://code.google.com/p/chromium/codesearch#chromium/src/chrome/browser/android/shortcut_helper.cc&l=42) first, if none are found it will search for the icon that closest matches the device characteristics.
+*  Chrome will [first look for icons](https://code.google.com/p/chromium/codesearch#chromium/src/chrome/browser/android/shortcut_helper.cc&l=182) that match the density of the display and are sized to [48dp * screen density](https://code.google.com/p/chromium/codesearch#chromium/src/chrome/browser/android/shortcut_helper.cc&l=42) first, if none are found it will search for the icon that closest matches the device characteristics. If, for whatever reason, you want be specific about targetting an icon at a particular-pixel density, you can use the [`density` member](http://w3c.github.io/manifest/#display-member). The `density` member takes a number. When you don't declare `density`, it just defaults to "1", which means "use this icon for screen densities 1.0 and up", which is normally what you want. 
 
 ## Telling the browser about your manifest
 


### PR DESCRIPTION
The usage of type and icon was incorrect. Those members should used to "discriminate" within a set of icons. The same with `type`: the semantics are "only use this icon if you support this type". The use case is for WebP or future file formats that are not universally supported.