### PR TITLE
300ms tap delay: remove quote from video embed URL

### DIFF
--- a/_posts/2013-12-13-300ms-tap-delay-gone-away.md
+++ b/_posts/2013-12-13-300ms-tap-delay-gone-away.md
@@ -24,7 +24,7 @@ permalink: /2013/12/300ms-tap-delay-gone-away
 <p>However, as of <a href="https://play.google.com/store/apps/details?id=com.chrome.beta">Chrome 32 for Android</a>, which is currently in beta, this <strong>delay is gone</strong> for <strong>mobile-optimised</strong> sites, <strong>without removing pinch-zooming</strong>!</p>
 
 
-{% video //www.youtube.com/embed/AjUpiwvIa5A?rel=0" %} {% endvideo %}
+{% video //www.youtube.com/embed/AjUpiwvIa5A?rel=0 %} {% endvideo %}
 
 <p>This optimisation applies to any site that uses:</p>
 


### PR DESCRIPTION
I was referencing this fine article and noticed the video embed didn't show up:

![screenshot 2015-02-16 16 34 02](https://cloud.githubusercontent.com/assets/254753/6214582/e9ca0056-b5f9-11e4-9b97-b7168c691311.png)

This particular embed had an extra quote character compared to the other embeds in the "responsive videos" commit: https://github.com/html5rocks/updates.html5rocks.com.new/commit/5ad765fdca8234cf2611098c4c3a3567470eb5e3