### PR TITLE
Fixes for Atom/RSS feed.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -10,7 +10,7 @@
     </aside>
     <aside class="panel rss">
       <h2>Subscribe</h2>
-      <p>Enjoyed this article? Grab the <a href="/rss">RSS feed</a> and stay up-to-date.</p>
+      <p>Enjoyed this article? Grab the <a href="/feeds/rss.xml">RSS feed</a> and stay up-to-date.</p>
     </aside>
     {% endif %}
     <p class="licensing">

--- a/atom.xml
+++ b/atom.xml
@@ -1,19 +1,21 @@
 ---
 layout: null
 ---
-<?xml version="1.0" encoding="UTF-8"?>
-<feed version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
     <title>{{ site.title | xml_escape }}</title>
     <subtitle>{{ site.description | xml_escape }}</subtitle>
-    <link href="{{ site.url }}{{ site.baseurl }}/" rel="self" />
-    <udpdated>{{ site.time | date_to_rfc822 }}</udpdated>
+    <link href="{{ '/feeds/atom.xml' | prepend: site.baseurl | prepend: site.html5rocks_url }}" rel="self" />
+    <link href="{{ site.html5rocks_url }}{{ site.baseurl }}" />
+    <id>{{ site.html5rocks_url }}{{ site.baseurl }}/</id>
+    <updated>{{ site.time | date_to_xmlschema }}</updated>
     {% for post in site.posts limit:10 %}
       <entry>
         <title>{{ post.title | xml_escape }}</title>
         <content type="html">{{ post.content | xml_escape }}</content>
-        <updated>{{ post.date | date_to_rfc822 }}</updated>
-        <link href="{{ post.url | prepend: site.baseurl | prepend: site.url }}" />
-        <id>{{ post.url | prepend: site.baseurl | prepend: site.url }}</id>
+        <updated>{{ post.date | date_to_xmlschema }}</updated>
+        <link href="{{ post.url | prepend: site.baseurl | prepend: site.html5rocks_url }}" />
+        <id>{{ post.url | prepend: site.baseurl | prepend: site.html5rocks_url }}</id>
       </entry>
     {% endfor %}
-</rss>
+</feed>

--- a/rss.xml
+++ b/rss.xml
@@ -2,12 +2,11 @@
 layout: null
 ---
 <?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0">
   <channel>
     <title>{{ site.title | xml_escape }}</title>
     <description>{{ site.description | xml_escape }}</description>
-    <link>{{ site.url }}{{ site.baseurl }}/</link>
-    <atom:link href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml" />
+    <link>{{ site.html5rocks_url }}{{ site.baseurl }}/</link>
     <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>
@@ -16,8 +15,8 @@ layout: null
         <title>{{ post.title | xml_escape }}</title>
         <description>{{ post.content | xml_escape }}</description>
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
-        <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
-        <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
+        <link>{{ post.url | prepend: site.baseurl | prepend: site.html5rocks_url }}</link>
+        <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.html5rocks_url }}</guid>
         {% for tag in post.tags %}
         <category>{{ tag | xml_escape }}</category>
         {% endfor %}


### PR DESCRIPTION
@devnook @PaulKinlan 

This resolves some validation errors reported by the http://validator.w3.org/feed/check.cgi tool in both the Atom and RSS feeds. The biggest problem, I think, was the use of incorrect URLs, because `site.url` is currently defined as `''`, and `site.html5rocks_url` needs to be used instead. It should resolve the issue in #74, but I'll wait until this goes live and I can check in Feedly before closing that issue.

We should clean up some of the `_site.yaml` metadata and stop using `site.html5rocks_url` here and elsewhere, but I wanted to keep this PR focused on just the RSS/Atom fixes, and opened #82 to track that.