### PR TITLE
Use site config variables, including in feeds.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,12 +1,8 @@
 # Site settings
-title: HTML5 Rocks - Chrome updates
-description: >
-  "HTML5Rocks updates stream."
+title: "HTML5 Rocks - Chrome updates"
+description: "HTML5Rocks updates stream."
 baseurl: ""
-# TODO: change link.
-url: ""
-# url: "http://localhost:8080"
-#url: "http://devnook.github.io/updates.html5rocks.com.new"
+url: "http://updates.html5rocks.com"
 html5rocks_url: "http://www.html5rocks.com"
 markdown: kramdown
 permalink: /:year/:month/:title

--- a/_includes/disqus.html
+++ b/_includes/disqus.html
@@ -3,7 +3,7 @@
     <h2>Comments</h2>
     <div id="disqus_thread">
       <a href="#disqus_thread" class="load-comments"
-          data-disqus-identifier="http://updates.html5rocks.com{{page.url}}">0</a>
+          data-disqus-identifier="{{ page.url | prepend: site.baseurl | prepend: site.url }}">0</a>
     </div>
   </div>
 
@@ -18,8 +18,8 @@
   <script>
 
     var disqus_shortname = 'html5rocks';
-    var disqus_identifier = 'http://updates.html5rocks.com{{page.url}}';
-    var disqus_url = 'http://updates.html5rocks.com{{page.url}}';
+    var disqus_identifier = '{{ page.url | prepend: site.baseurl | prepend: site.url }}';
+    var disqus_url = '{{ page.url | prepend: site.baseurl | prepend: site.url }}';
     var disqus_developer = 0;
 
     var disqus_config = function () {

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,13 +4,13 @@
     <h1>Next steps</h1>
     <aside class="panel share">
       <h2>Share</h2>
-        <a href="https://twitter.com/share?url=http://www.html5rocks.com/tutorials/shapes/getting-started/&amp;text=Getting Started with CSS Shapes&amp;lang=en&amp;via=ChromiumDev&amp;related=ChromiumDev" class="twitter" target="_blank">Twitter</a>
-        <a href="https://www.facebook.com/sharer/sharer.php?u=http://www.html5rocks.com/tutorials/shapes/getting-started/" class="facebook" target="_blank">Facebook</a>
-        <a href="https://plus.google.com/share?url=http://www.html5rocks.com/tutorials/shapes/getting-started/" class="gplus" onclick="javascript:window.open(this.href, '', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=600,width=600');return false;">Google+</a>
+        <a href="https://twitter.com/share?url={{ page.url | prepend: site.baseurl | prepend: site.url }}&amp;text={{page.description | truncate: 97, '...' | uri_escape }}&amp;lang=en&amp;via=ChromiumDev&amp;related=ChromiumDev" class="twitter" target="_blank">Twitter</a>
+        <a href="https://www.facebook.com/sharer/sharer.php?u={{ page.url | prepend: site.baseurl | prepend: site.url }}" class="facebook" target="_blank">Facebook</a>
+        <a href="https://plus.google.com/share?url={{ page.url | prepend: site.baseurl | prepend: site.url }}" class="gplus" onclick="javascript:window.open(this.href, '', 'menubar=no,toolbar=no,resizable=yes,scrollbars=yes,height=600,width=600');return false;">Google+</a>
     </aside>
     <aside class="panel rss">
       <h2>Subscribe</h2>
-      <p>Enjoyed this article? Grab the <a href="/feeds/rss.xml">RSS feed</a> and stay up-to-date.</p>
+      <p>Enjoyed this article? Grab the <a href="{{ '/feeds/rss.xml' | prepend: site.baseurl | prepend: site.url }}">RSS feed</a> and stay up-to-date.</p>
     </aside>
     {% endif %}
     <p class="licensing">

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,22 +3,22 @@
   <nav id="sitenav" class="container">
     <ul>
       <li id="tutorials_menu">
-        <a href="http://www.html5rocks.com" class="tutorials">Home</a>
+        <a href="{{ site.html5rocks_url }}" class="tutorials">Home</a>
       </li>
       <li id="tutorials_menu">
-        <a href="http://www.html5rocks.com/en/tutorials/?page=1" class="tutorials">Tutorials</a>
+        <a href="{{ '/en/tutorials/?page=1' | prepend: site.html5rocks_url }}" class="tutorials">Tutorials</a>
       </li>
       <li id="updates_menu">
-        <a href="http://www.html5rocks.com/en/updates" class="updates">Updates</a>
+        <a href="{{ '/en/updates' | prepend: site.html5rocks_url }}" class="updates">Updates</a>
       </li>
       <li id="contrib_menu">
         <a href="https://github.com/html5rocks/www.html5rocks.com/blob/master/CONTRIBUTING.md" target="_blank">Contribute</a>
       </li>
       <li id="slides_menu">
-        <a href="http://www.html5rocks.com/en/slides" class="slides">Slides</a>
+        <a href="{{ '/en/slides' | prepend: site.html5rocks_url }}" class="slides">Slides</a>
       </li>
       <li id="resources_menu">
-        <a href="http://www.html5rocks.com/en/resources" class="resources">Resources</a>
+        <a href="{{ '/en/resources' | prepend: site.html5rocks_url }}" class="resources">Resources</a>
       </li>
     </ul>
   </nav>

--- a/_layouts/tag_index.html
+++ b/_layouts/tag_index.html
@@ -8,7 +8,7 @@ layout: default
         {% for post in site.posts %}
           {% if post.tags contains page.tag %}
           <li>
-            <a href="{{ post.url | prepend: site.url }}">
+            <a href="{{ post.url | prepend: site.baseurl }}">
               <span class="left">
               {% for author in post.authors %}
                 {% include avatar.html author=author%}
@@ -27,7 +27,7 @@ layout: default
               <span class="clear"></span>
             </a>
           </li>
-          {%endif%}
+          {% endif %}
         {% endfor %}
       </ul>
     </div>

--- a/atom.xml
+++ b/atom.xml
@@ -5,17 +5,20 @@ layout: null
 <feed xmlns="http://www.w3.org/2005/Atom">
     <title>{{ site.title | xml_escape }}</title>
     <subtitle>{{ site.description | xml_escape }}</subtitle>
-    <link href="{{ '/feeds/atom.xml' | prepend: site.baseurl | prepend: site.html5rocks_url }}" rel="self" />
-    <link href="{{ site.html5rocks_url }}{{ site.baseurl }}" />
-    <id>{{ site.html5rocks_url }}{{ site.baseurl }}/</id>
+    <link href="{{ '/feeds/atom.xml' | prepend: site.baseurl | prepend: site.url }}" rel="self" />
+    <link href="{{ site.url }}{{ site.baseurl }}" />
+    <id>{{ site.url }}{{ site.baseurl }}/</id>
     <updated>{{ site.time | date_to_xmlschema }}</updated>
     {% for post in site.posts limit:10 %}
       <entry>
         <title>{{ post.title | xml_escape }}</title>
-        <content type="html">{{ post.content | xml_escape }}</content>
+        <content type="html"><![CDATA[{{ post.content }}]]></content>
         <updated>{{ post.date | date_to_xmlschema }}</updated>
-        <link href="{{ post.url | prepend: site.baseurl | prepend: site.html5rocks_url }}" />
-        <id>{{ post.url | prepend: site.baseurl | prepend: site.html5rocks_url }}</id>
+        <link href="{{ post.url | prepend: site.baseurl | prepend: "http://updates.html5rocks.com" }}" />
+        <id>{{ post.url | prepend: site.baseurl | prepend: site.url }}</id>
+        <author>
+          <name>{{ post.authors | join: ", " }}</name>
+        </author>
       </entry>
     {% endfor %}
 </feed>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ subtitle: "New hotness from the HTML5 world"
       <ul class="clearfix">
         {% for post in paginator.posts %}
           <li>
-            <a href="{{ post.url | prepend: site.url }}">
+            <a href="{{ post.url | prepend: site.baseurl }}">
               <span class="left">
               {% for author in post.authors %}
                 {% include avatar.html author=author%}

--- a/rss.xml
+++ b/rss.xml
@@ -2,21 +2,22 @@
 layout: null
 ---
 <?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>{{ site.title | xml_escape }}</title>
     <description>{{ site.description | xml_escape }}</description>
-    <link>{{ site.html5rocks_url }}{{ site.baseurl }}/</link>
+    <link>{{ site.url }}{{ site.baseurl }}</link>
     <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
+    <atom:link href="{{ '/feeds/rss.xml' | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml" />
     <generator>Jekyll v{{ jekyll.version }}</generator>
     {% for post in site.posts limit:10 %}
       <item>
         <title>{{ post.title | xml_escape }}</title>
-        <description>{{ post.content | xml_escape }}</description>
+        <description><![CDATA[{{ post.content }}]]></description>
         <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
-        <link>{{ post.url | prepend: site.baseurl | prepend: site.html5rocks_url }}</link>
-        <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.html5rocks_url }}</guid>
+        <link>{{ post.url | prepend: site.baseurl | prepend: site.url }}</link>
+        <guid isPermaLink="true">{{ post.url | prepend: site.baseurl | prepend: site.url }}</guid>
         {% for tag in post.tags %}
         <category>{{ tag | xml_escape }}</category>
         {% endfor %}


### PR DESCRIPTION
@devnook @PaulKinlan 

This addresses some TODOs in the origin `_config.yml` by populating `site.url` with the production URL. It adjusts the URLs used in various templates to account for that.

It's also another attempt at getting the Atom + RSS feeds happy, by using that correct URL and also by wrapping the HTML content in `CDATA`.

I'd like to test this on the staging server first so that Feedly can hit the updated feeds and confirm that they look good, so please don't merge with master yet.