### PR TITLE
Fix GitHub URL with line information to its canonical form

### DIFF
--- a/_posts/2012-08-30-Stick-your-landings-position-sticky-lands-in-WebKit.md
+++ b/_posts/2012-08-30-Stick-your-landings-position-sticky-lands-in-WebKit.md
@@ -50,7 +50,7 @@ To illustrate this feature in a practical setting, I've put together a [DEMO](ht
 
 ### Old approach: scroll events
 
-Until now, to achieve the sticky effect, sites setup `scroll` event listeners in JS. We actually use [this technique](https://github.com/html5rocks/www.html5rocks.com/blob/master/templates/base.html#L417) as well on html5rocks tutorials. On screens smaller than 1200px, our table of contents sidebar changes to `position: fixed` after a certain amount of scrolling.
+Until now, to achieve the sticky effect, sites setup `scroll` event listeners in JS. We actually use [this technique](https://github.com/html5rocks/www.html5rocks.com/blob/a8b383c59a5aceb5ae4588809adc4094ee767349/templates/base.html#L417) as well on html5rocks tutorials. On screens smaller than 1200px, our table of contents sidebar changes to `position: fixed` after a certain amount of scrolling.
 
 Here's the (now old way) to have a header that sticks to the top of the viewport when the user scrolls down, and falls back into place when the user scrolls up:
 


### PR DESCRIPTION
Links to sources on GitHub with line references must include specific commit sha in order to protect the reference from consequent commits.

The article [“Stick your landings! position: sticky lands in WebKit”](http://updates.html5rocks.com/2012/08/Stick-your-landings-position-sticky-lands-in-WebKit) references a specific line in [templates/base.html](https://github.com/html5rocks/www.html5rocks.com/blob/master/templates/base.html) which is out of date. In fact, it was already out of date on the date of publication!
