### PR TITLE
Changes for the 2.0.0 syntax.

### DIFF
--- a/_posts/2015-02-23-offline-first-with-sw-precache.md
+++ b/_posts/2015-02-23-offline-first-with-sw-precache.md
@@ -4,7 +4,7 @@ title: "Offline-first, fast, with the sw-precache module"
 description: "Add service worker-powered offline capabilities to your site with the sw-precache module."
 article:
   written_on: 2015-02-23
-  updated_on: 2015-02-23
+  updated_on: 2015-06-17
 authors:
   - jeffposnick
 tags:
@@ -57,20 +57,15 @@ Here’s a basic example of using <code>sw-precache</code> as part of a <code>gu
 
 {% highlight javascript %}
 gulp.task('generate-service-worker', function(callback) {
-  var fs = require('fs');
   var path = require('path');
   var swPrecache = require('sw-precache');
   var rootDir = 'app';
 
-  swPrecache({
+  swPrecache.write(path.join(rootDir, 'service-worker.js'), {
     staticFileGlobs: [rootDir + '/**/*.{js,html,css,png,jpg,gif}'],
-    stripPrefix: rootDir
-  }, function(error, swFileContents) {
-    if (error) {
-      return callback(error);
-    }
-    fs.writeFile(path.join(rootDir, 'service-worker.js'), swFileContents, callback);
-  });
+    stripPrefix: rootDir,
+    verbose: true
+  }, callback);
 });
 {% endhighlight %}
 


### PR DESCRIPTION
R: @PaulKinlan 

Small change to the inline sample to account for the new `sw-precache` syntax in the 2.0.0 release.